### PR TITLE
Remove gulpplugin keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "site",
     "website",
     "gulp",
-    "gulpplugin",
     "gh-pages",
     "dist",
     "github"


### PR DESCRIPTION
This plugin shouldn't be shown on http://gulpjs.com/plugins/.

Please read [gulpjs/plugins#blacklisting](https://github.com/gulpjs/plugins#blacklisting):

> A plugin may be blacklisted for the following reasons:
> 1. Does not fit within the gulp paradigm
> 2. Flagrant duplicate of an existing plugin
> 3. Does not follow the plugin guidelines

This plugin meets 2 and 3. I'm really sad that you've published it to npm.
